### PR TITLE
Update produce_chromium_extension_list.sh

### DIFF
--- a/extensions/chromium/produce_chromium_extension_list.sh
+++ b/extensions/chromium/produce_chromium_extension_list.sh
@@ -8,5 +8,5 @@ cat "./sources.txt" | while read link
 do
     echo "Parsing $link"
     escaped_link=$(printf '%s\n' "$link" | sed -e 's/[]\/$*.^[]/\\&/g');
-    curl -sL $link | egrep -o "[a-z]{32}" | sort | uniq | sed "s/$/,\"${escaped_link}\"/g" >> suspicious_chromium_extensions.csv
+    curl -sL $link | egrep -o "\b[a-z]{32}\b" | sort | uniq | sed "s/$/,\"${escaped_link}\"/g" >> suspicious_chromium_extensions.csv
 done


### PR DESCRIPTION
add word boundary to more accurately identify extensionIDs. Note will have the side effect of no longer matching the old bundlebot false positive: https://www.threatdown.com/blog/criminals-target-businesses-with-malicious-extension-for-metas-ads-manager-and-accidentally-leak-stolen-accounts/